### PR TITLE
MAJOR FIX: Register Missing Brokers

### DIFF
--- a/DMX.Portal.Web.Infrastructure.Build/Program.cs
+++ b/DMX.Portal.Web.Infrastructure.Build/Program.cs
@@ -29,7 +29,7 @@ var githubPipeline = new GithubPipeline
         Build = new BuildJob
         {
             RunsOn = BuildMachines.Windows2022,
-            
+
             Steps = new List<GithubTask>
             {
                 new CheckoutTaskV2

--- a/DMX.Portal.Web.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.RetrieveAll.cs
+++ b/DMX.Portal.Web.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.RetrieveAll.cs
@@ -18,20 +18,24 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
     public partial class LabServiceTests
     {
         [Theory]
-        [MemberData(nameof(CriticalDependencyException))]
+        [MemberData(nameof(CriticalDependencyExceptions))]
         public async Task ShouldThrowCriticalDependencyExceptionOnRetrievalIfCriticalErrorOccursAndLogItAsync(
             Xeption criticalDependencyException)
         {
             // given
-            var failedExternalLabDependencyException = new FailedLabDependencyException(criticalDependencyException);
-            var expectedLabDependencyException = new LabDependencyException(failedExternalLabDependencyException);
+            var failedExternalLabDependencyException = 
+                new FailedLabDependencyException(criticalDependencyException);
+            
+            var expectedLabDependencyException =
+                new LabDependencyException(failedExternalLabDependencyException);
 
             this.dmxApiBrokerMock.Setup(broker =>
                 broker.GetAllLabsAsync())
                     .ThrowsAsync(criticalDependencyException);
 
             // when
-            ValueTask<List<Lab>> getAllLabsTask = this.labService.RetrieveAllLabsAsync();
+            ValueTask<List<Lab>> getAllLabsTask = 
+                this.labService.RetrieveAllLabsAsync();
 
             // then
             await Assert.ThrowsAsync<LabDependencyException>(() =>
@@ -56,17 +60,23 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
             // given
             string someMessage = GetRandomString();
             var someResponseMessage = new HttpResponseMessage();
-            HttpResponseException httpResponseException = new HttpResponseException(someResponseMessage, someMessage);
             
-            var failedExternalLabDependencyException = new FailedLabDependencyException(httpResponseException);
-            var expectedLabDependencyException = new LabDependencyException(failedExternalLabDependencyException);
+            var httpResponseException =
+                new HttpResponseException(someResponseMessage, someMessage);
+
+            var failedExternalLabDependencyException =
+                new FailedLabDependencyException(httpResponseException);
+            
+            var expectedLabDependencyException = new
+                LabDependencyException(failedExternalLabDependencyException);
 
             this.dmxApiBrokerMock.Setup(broker =>
                 broker.GetAllLabsAsync())
                     .ThrowsAsync(httpResponseException);
 
             // when
-            ValueTask<List<Lab>> getAllLabsTask = this.labService.RetrieveAllLabsAsync();
+            ValueTask<List<Lab>> getAllLabsTask =
+                this.labService.RetrieveAllLabsAsync();
 
             // then
             await Assert.ThrowsAsync<LabDependencyException>(() =>
@@ -91,10 +101,10 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
             // given
             var serviceException = new Exception();
 
-            var failedExternalLabServiceException = 
+            var failedExternalLabServiceException =
                 new FailedLabServiceException(serviceException);
-            
-            var expectedLabServiceException = 
+
+            var expectedLabServiceException =
                 new LabServiceException(failedExternalLabServiceException);
 
             this.dmxApiBrokerMock.Setup(broker =>

--- a/DMX.Portal.Web.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.RetrieveAll.cs
+++ b/DMX.Portal.Web.Tests.Unit/Services/Foundations/Labs/LabServiceTests.Exceptions.RetrieveAll.cs
@@ -23,11 +23,11 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
             Xeption criticalDependencyException)
         {
             // given
-            var failedExternalLabDependencyException = 
+            var failedLabDependencyException = 
                 new FailedLabDependencyException(criticalDependencyException);
             
             var expectedLabDependencyException =
-                new LabDependencyException(failedExternalLabDependencyException);
+                new LabDependencyException(failedLabDependencyException);
 
             this.dmxApiBrokerMock.Setup(broker =>
                 broker.GetAllLabsAsync())
@@ -64,11 +64,11 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
             var httpResponseException =
                 new HttpResponseException(someResponseMessage, someMessage);
 
-            var failedExternalLabDependencyException =
+            var failedLabDependencyException =
                 new FailedLabDependencyException(httpResponseException);
             
             var expectedLabDependencyException = new
-                LabDependencyException(failedExternalLabDependencyException);
+                LabDependencyException(failedLabDependencyException);
 
             this.dmxApiBrokerMock.Setup(broker =>
                 broker.GetAllLabsAsync())
@@ -101,11 +101,11 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
             // given
             var serviceException = new Exception();
 
-            var failedExternalLabServiceException =
+            var failedLabServiceException =
                 new FailedLabServiceException(serviceException);
 
             var expectedLabServiceException =
-                new LabServiceException(failedExternalLabServiceException);
+                new LabServiceException(failedLabServiceException);
 
             this.dmxApiBrokerMock.Setup(broker =>
                 broker.GetAllLabsAsync())

--- a/DMX.Portal.Web.Tests.Unit/Services/Foundations/Labs/LabServiceTests.cs
+++ b/DMX.Portal.Web.Tests.Unit/Services/Foundations/Labs/LabServiceTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Net.Http;
-using Bunit.Asserting;
 using DMX.Portal.Web.Brokers.DmxApis;
 using DMX.Portal.Web.Brokers.Loggings;
 using DMX.Portal.Web.Models.Labs;
@@ -36,7 +35,7 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
                 loggingBroker: this.loggingBrokerMock.Object);
         }
 
-        public static TheoryData CriticalDependencyException()
+        public static TheoryData CriticalDependencyExceptions()
         {
             string someMessage = GetRandomString();
             var someResponseMessage = new HttpResponseMessage();
@@ -49,6 +48,14 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
             };
         }
 
+        private Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException)
+        {
+            return actualExpectedAssertException =>
+                actualExpectedAssertException.Message == expectedException.Message &&
+                actualExpectedAssertException.InnerException.Message == expectedException.InnerException.Message &&
+                (actualExpectedAssertException.InnerException as Xeption).DataEquals(expectedException.InnerException.Data);
+        }
+
         private static string GetRandomString() =>
             new MnemonicString().GetValue();
 
@@ -58,19 +65,7 @@ namespace DMX.Portal.Web.Tests.Unit.Services.Foundations.Labs
         private static int GetRandomNumber() =>
             new IntRange(min: 2, max: 10).GetValue();
 
-        private static Filler<Lab> CreateLabFiller()
-        {
-            var filler = new Filler<Lab>();
-
-            return filler;
-        }
-
-        private Expression<Func<Xeption, bool>> SameExceptionAs(Xeption expectedException)
-        {
-            return actualExpectedAssertException =>
-                actualExpectedAssertException.Message == expectedException.Message &&
-                actualExpectedAssertException.InnerException.Message == expectedException.InnerException.Message &&
-                (actualExpectedAssertException.InnerException as Xeption).DataEquals(expectedException.InnerException.Data);
-        }
+        private static Filler<Lab> CreateLabFiller() =>
+            new Filler<Lab>();
     }
 }

--- a/DMX.Portal.Web/Brokers/DmxApis/IDmxApiBroker.Labs.cs
+++ b/DMX.Portal.Web/Brokers/DmxApis/IDmxApiBroker.Labs.cs
@@ -2,9 +2,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. 
 // ---------------------------------------------------------------
 
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DMX.Portal.Web.Models.Labs;
+
 namespace DMX.Portal.Web.Brokers.DmxApis
 {
     public partial interface IDmxApiBroker
     {
+        ValueTask<List<Lab>> GetAllLabsAsync();
     }
 }

--- a/DMX.Portal.Web/Brokers/DmxApis/IDmxApiBroker.cs
+++ b/DMX.Portal.Web/Brokers/DmxApis/IDmxApiBroker.cs
@@ -2,14 +2,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. 
 // ---------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DMX.Portal.Web.Models.Labs;
-
 namespace DMX.Portal.Web.Brokers.DmxApis
 {
     public partial interface IDmxApiBroker
     {
-        ValueTask<List<Lab>> GetAllLabsAsync();
+
     }
 }

--- a/DMX.Portal.Web/Program.cs
+++ b/DMX.Portal.Web/Program.cs
@@ -16,8 +16,7 @@ namespace DMX.Portal.Web
         {
             return Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
-                    webBuilder.UseStartup<Startup>()
-                );
+                    webBuilder.UseStartup<Startup>());
         }
     }
 }

--- a/DMX.Portal.Web/Services/Foundations/Labs/LabService.cs
+++ b/DMX.Portal.Web/Services/Foundations/Labs/LabService.cs
@@ -25,6 +25,5 @@ namespace DMX.Portal.Web.Services.Foundations.Labs
 
         public ValueTask<List<Lab>> RetrieveAllLabsAsync() =>
         TryCatch(async () => await this.dmxApiBroker.GetAllLabsAsync());
-
     }
 }

--- a/DMX.Portal.Web/Startup.cs
+++ b/DMX.Portal.Web/Startup.cs
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------
 
 using DMX.Portal.Web.Brokers.DmxApis;
+using DMX.Portal.Web.Brokers.Loggings;
 using DMX.Portal.Web.Services.Foundations.Labs;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -54,8 +55,11 @@ namespace DMX.Portal.Web
             });
         }
 
-        private static void AddBrokers(IServiceCollection services) =>
+        private static void AddBrokers(IServiceCollection services)
+        {
+            services.AddTransient<ILoggingBroker, LoggingBroker>();
             services.AddTransient<IDmxApiBroker, DmxApiBroker>();
+        }
 
         private static void AddServices(IServiceCollection services) =>
             services.AddTransient<ILabService, LabService>();


### PR DESCRIPTION
Included in this PR:
1. Register missing brokers to enable the application to run.
2. Breakdown methods with a big belly :-) 
3. Run Code Clean Up across the entire solution
4. Move `GetAllLabsAsync` method into it's proper partial class file
5. Move `Filler` methods to the bottom and most exposed methods to the top in test files
6. Remove all instances of using `External` in any service
7. Rename data for multiple tests to be plural from `CriticalDependencyException` to `CriticalDependencyExceptions`